### PR TITLE
Update JVM language level to `17`

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,7 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="11" />
+        <option name="gradleJvm" value="corretto-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@
 ## [Unreleased]
 ### Added
 - Initial scaffold created from [IntelliJ Platform Plugin Template](https://github.com/JetBrains/intellij-platform-plugin-template)
+
+### Changed
+- Update JVM language level to `17`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ repositories {
 
 // Set the JVM language level used to build the project. Use Java 11 for 2020.3+, and Java 17 for 2022.2+.
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(17)
 }
 
 // Configure Gradle IntelliJ Plugin - read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,12 +7,12 @@ pluginRepositoryUrl = https://github.com/stkale/crispy-spoon
 pluginVersion = 0.0.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 221
+pluginSinceBuild = 223
 pluginUntilBuild = 231.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
-platformVersion = 2022.1.4
+platformVersion = 2022.3.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22

--- a/src/main/kotlin/com/github/stkale/spoon/listeners/MyFrameStateListener.kt
+++ b/src/main/kotlin/com/github/stkale/spoon/listeners/MyFrameStateListener.kt
@@ -2,10 +2,11 @@ package com.github.stkale.spoon.listeners
 
 import com.intellij.ide.FrameStateListener
 import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.wm.IdeFrame
 
 internal class MyFrameStateListener : FrameStateListener {
 
-    override fun onFrameActivated() {
+    override fun onFrameActivated(ideFrame: IdeFrame) {
         thisLogger().warn("Don't forget to remove all non-needed sample code files with their corresponding registration entries in `plugin.xml`.")
     }
 }

--- a/src/main/kotlin/com/github/stkale/spoon/toolWindow/MyToolWindowFactory.kt
+++ b/src/main/kotlin/com/github/stkale/spoon/toolWindow/MyToolWindowFactory.kt
@@ -18,7 +18,7 @@ class MyToolWindowFactory : ToolWindowFactory {
         thisLogger().warn("Don't forget to remove all non-needed sample code files with their corresponding registration entries in `plugin.xml`.")
     }
 
-    private val contentFactory = ContentFactory.SERVICE.getInstance()
+    private val contentFactory = ContentFactory.getInstance()
 
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         val myToolWindow = MyToolWindow(toolWindow)


### PR DESCRIPTION
Update JVM language level used to build the project to `17`.

Also, update `pluginSinceBuild` in accordance with [IntelliJ Project Migrates to Java 17](https://blog.jetbrains.com/platform/2022/08/intellij-project-migrates-to-java-17/?_ga=2.245707779.687717418.1679486936-103614729.1679486936) and refactor deprecated code.